### PR TITLE
fix: remove deprecated package-name parameter from release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,4 +19,3 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           release-type: go
-          package-name: observability-log


### PR DESCRIPTION
The package-name parameter is deprecated in release-please v4. The action will automatically detect the package name from go.mod.