### PR TITLE
Implement auto-discovery for fuzz tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,34 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  discover-fuzz-tests:
+    name: Discover Fuzz Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tests: ${{ steps.find-tests.outputs.tests }}
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Find fuzz tests
+        id: find-tests
+        run: |
+          TESTS=$(find . -name "*_fuzz_test.go" -o -name "*_test.go" | while read file; do
+            pkg=$(dirname "$file")
+            grep -h '^func Fuzz' "$file" 2>/dev/null | sed 's/func \(Fuzz[^(]*\).*/\1/' | while read test; do
+              echo "${test}:${pkg}"
+            done
+          done | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "tests=$TESTS" >> $GITHUB_OUTPUT
+
   fuzz:
     name: Fuzz (${{ matrix.fuzz-test }})
     runs-on: ubuntu-latest
@@ -69,20 +97,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fuzz-test:
-          - "FuzzLogMessages:."
-          - "FuzzLogLevel:."
-          - "FuzzLoggerWithFields:."
-          - "FuzzNewLogger:."
-          - "FuzzLoggerMultipleFields:."
-          - "FuzzUserAgent:./fields"
-          - "FuzzService:./fields"
-          - "FuzzSource:./fields"
-          - "FuzzURL:./fields"
-          - "FuzzHTTPRequest:./fields"
-          - "FuzzCoreWrite:./sentry"
-          - "FuzzCoreWriteWithFields:./sentry"
-          - "FuzzCoreWriteWithError:./sentry"
+        fuzz-test: ${{ fromJson(needs.discover-fuzz-tests.outputs.tests) }}
+    needs: discover-fuzz-tests
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -99,7 +115,7 @@ jobs:
           go-version: 1.25.x
 
       - name: Run fuzz test
-        run: make fuzz-single FUZZ_TEST="${{ matrix.fuzz-test }}"
+        run: make fuzz FUZZ_TEST="${{ matrix.fuzz-test }}"
 
   release:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ifdef FUZZ_TEST
 	if [ -z "$$FUZZ_PKG" ] || [ "$$FUZZ_PKG" = "$$FUZZ_NAME" ]; then \
 		FUZZ_PKG="."; \
 	fi; \
-	go test -run=^$$ -fuzz=$$FUZZ_NAME -fuzztime=30s $$FUZZ_PKG
+	go test -run=^$$ -fuzz=^$$FUZZ_NAME$$ -fuzztime=30s $$FUZZ_PKG
 	@echo "Done!"
 else
 	@echo "Running all fuzz tests..."
@@ -41,7 +41,7 @@ else
 		pkg=$$(dirname $$file); \
 		for test in $$(grep -h '^func Fuzz' $$file 2>/dev/null | sed 's/func \(Fuzz[^(]*\).*/\1/'); do \
 			echo "Running $$test in $$pkg..."; \
-			go test -run=^$$ -fuzz=$$test -fuzztime=30s $$pkg || exit 1; \
+			go test -run=^$$ -fuzz=^$$test$$ -fuzztime=30s $$pkg || exit 1; \
 		done; \
 	done
 	@echo "All fuzz tests completed successfully!"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt test lint build clean fuzz fuzz-single
+.PHONY: help fmt test lint build clean fuzz
 SHELL := /bin/bash
 
 ## help: Display this help message
@@ -7,8 +7,7 @@ help:
 	@echo "  fmt         - Format code using gofmt"
 	@echo "  lint        - Run golangci-lint"
 	@echo "  test        - Run tests with coverage"
-	@echo "  fuzz        - Run all fuzz tests (30s each)"
-	@echo "  fuzz-single - Run a single fuzz test (FUZZ_TEST=FuzzName:package)"
+	@echo "  fuzz        - Run all fuzz tests (or specific test with FUZZ_TEST=FuzzName)"
 	@echo "  build       - Build the project"
 	@echo "  clean       - Clean build artifacts"
 	@echo "  help        - Display this help message"
@@ -27,32 +26,26 @@ test:
 
 ## fuzz: Run fuzz tests for 30 seconds each
 fuzz:
-	@echo "Running fuzz tests (30s each)..."
-	@go test -fuzz=FuzzLogMessages -fuzztime=30s .
-	@go test -fuzz=FuzzLogLevel -fuzztime=30s .
-	@go test -fuzz=FuzzLoggerWithFields -fuzztime=30s .
-	@go test -fuzz=FuzzNewLogger -fuzztime=30s .
-	@go test -fuzz=FuzzLoggerMultipleFields -fuzztime=30s .
-	@go test -fuzz=FuzzUserAgent -fuzztime=30s ./fields
-	@go test -fuzz=FuzzService -fuzztime=30s ./fields
-	@go test -fuzz=FuzzSource -fuzztime=30s ./fields
-	@go test -fuzz=FuzzURL -fuzztime=30s ./fields
-	@go test -fuzz=FuzzHTTPRequest -fuzztime=30s ./fields
-	@go test -fuzz=FuzzCoreWrite -fuzztime=30s ./sentry
-	@go test -fuzz=FuzzCoreWriteWithFields -fuzztime=30s ./sentry
-	@go test -fuzz=FuzzCoreWriteWithError -fuzztime=30s ./sentry
-	@echo "All fuzz tests completed successfully!"
-
-## fuzz-single: Run a single fuzz test (usage: make fuzz-single FUZZ_TEST=FuzzName:package)
-fuzz-single:
-	@if [ -z "$(FUZZ_TEST)" ]; then \
-		echo "Error: FUZZ_TEST is required. Usage: make fuzz-single FUZZ_TEST=FuzzName:package"; \
-		exit 1; \
-	fi
+ifdef FUZZ_TEST
+	@echo "Running fuzz test: $(FUZZ_TEST)..."
 	@FUZZ_NAME=$$(echo "$(FUZZ_TEST)" | cut -d':' -f1); \
 	FUZZ_PKG=$$(echo "$(FUZZ_TEST)" | cut -d':' -f2); \
-	echo "Running fuzz test: $$FUZZ_NAME in package $$FUZZ_PKG"; \
-	go test -fuzz="^$$FUZZ_NAME$$" -fuzztime=30s $$FUZZ_PKG
+	if [ -z "$$FUZZ_PKG" ] || [ "$$FUZZ_PKG" = "$$FUZZ_NAME" ]; then \
+		FUZZ_PKG="."; \
+	fi; \
+	go test -run=^$$ -fuzz=$$FUZZ_NAME -fuzztime=30s $$FUZZ_PKG
+	@echo "Done!"
+else
+	@echo "Running all fuzz tests..."
+	@for file in $$(find . -name "*_fuzz_test.go" -o -name "*_test.go" | grep -E "(fuzz|_test\.go$$)"); do \
+		pkg=$$(dirname $$file); \
+		for test in $$(grep -h '^func Fuzz' $$file 2>/dev/null | sed 's/func \(Fuzz[^(]*\).*/\1/'); do \
+			echo "Running $$test in $$pkg..."; \
+			go test -run=^$$ -fuzz=$$test -fuzztime=30s $$pkg || exit 1; \
+		done; \
+	done
+	@echo "All fuzz tests completed successfully!"
+endif
 
 ## build: Build the project
 build:


### PR DESCRIPTION
- Replace hardcoded fuzz test list with dynamic discovery
- Add discover-fuzz-tests job to CI workflow
- Consolidate fuzz and fuzz-single into single fuzz target
- Now discovers all 25 fuzz tests across all packages