### PR TITLE
fix: add missing release history to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,72 @@
 * reset CHANGELOG to minimal header for release-please regeneration ([#23](https://github.com/pixelfactory-go/observability-log/issues/23)) ([6ea4075](https://github.com/pixelfactory-go/observability-log/commit/6ea4075de2dc1c3084cccf85fe425af7f37881cd))
 * update release-please workflow token permissions ([#20](https://github.com/pixelfactory-go/observability-log/issues/20)) ([0ec72d2](https://github.com/pixelfactory-go/observability-log/commit/0ec72d24cdfa904ebd26312617f62e1667814f08))
 
-## Changelog
+## [1.4.1](https://github.com/pixelfactory-go/observability-log/compare/v1.4.0...v1.4.1) (2026-01-21)
+
+
+### Bug Fixes
+
+* update CodeQL workflow to trigger on all branches ([a443c26](https://github.com/pixelfactory-go/observability-log/commit/a443c2653a78ac366a4568bc4fbeabc7a62e6610))
+
+## [1.4.0](https://github.com/pixelfactory-go/observability-log/compare/v1.3.2...v1.4.0) (2026-01-21)
+
+
+### Features
+
+* add comprehensive OSS-Fuzz integration with native Go fuzzing ([#16](https://github.com/pixelfactory-go/observability-log/issues/16)) ([e2e011e](https://github.com/pixelfactory-go/observability-log/commit/e2e011ec1adbd4adda2776ba5d4e75e08168c76e))
+
+## [1.3.2](https://github.com/pixelfactory-go/observability-log/compare/v1.3.1...v1.3.2) (2026-01-21)
+
+
+### Bug Fixes
+
+* add name to test job in CI configuration ([#14](https://github.com/pixelfactory-go/observability-log/issues/14)) ([adcf7c6](https://github.com/pixelfactory-go/observability-log/commit/adcf7c6e8dc998cd4e8e2f6bc21af4b7d1c6b541))
+
+## [1.3.1](https://github.com/pixelfactory-go/observability-log/compare/v1.3.0...v1.3.1) (2026-01-19)
+
+
+### Bug Fixes
+
+* remove deprecated package-name parameter from release-please ([#9](https://github.com/pixelfactory-go/observability-log/issues/9)) ([cf27170](https://github.com/pixelfactory-go/observability-log/commit/cf271700e404940604ab75b2f322aaccb944d539))
+
+## [1.3.0](https://github.com/pixelfactory-go/observability-log/compare/v1.2.0...v1.3.0) (2024-09-10)
+
+
+### Bug Fixes
+
+* update to go version 1.23 ([#7](https://github.com/pixelfactory-go/observability-log/issues/7)) ([e995bdf](https://github.com/pixelfactory-go/observability-log/commit/e995bdf66e13adb71e50ea2dd33773c25758ed70))
+
+## [1.2.0](https://github.com/pixelfactory-go/observability-log/compare/v1.1.2...v1.2.0) (2024-02-19)
+
+
+### Features
+
+* return struct not interface ([#6](https://github.com/pixelfactory-go/observability-log/issues/6)) ([6519497](https://github.com/pixelfactory-go/observability-log/commit/6519497941909b3c54740b8938d3fa5d089d563e))
+
+## [1.1.2](https://github.com/pixelfactory-go/observability-log/compare/v1.1.0...v1.1.2) (2024-01-04)
+
+
+### Bug Fixes
+
+* update ecszap to version v0.3.0 ([#5](https://github.com/pixelfactory-go/observability-log/issues/5)) ([aaf28ad](https://github.com/pixelfactory-go/observability-log/commit/aaf28ad04277a1328f53cf834e2ca8a64e66e662))
+
+## [1.1.0](https://github.com/pixelfactory-go/observability-log/compare/v1.0.1...v1.1.0) (2023-10-19)
+
+
+### Features
+
+* use fields package ([#3](https://github.com/pixelfactory-go/observability-log/issues/3)) ([a8e6ffc](https://github.com/pixelfactory-go/observability-log/commit/a8e6ffccd87d54ea077d226526e63fc9e010f90e))
+
+## [1.0.1](https://github.com/pixelfactory-go/observability-log/compare/v1.0.0...v1.0.1) (2023-08-20)
+
+
+### Bug Fixes
+
+* update README ([#2](https://github.com/pixelfactory-go/observability-log/issues/2)) ([fb61295](https://github.com/pixelfactory-go/observability-log/commit/fb612956907766589ceb4d441651d303949d28f3))
+
+## [1.0.0](https://github.com/pixelfactory-go/observability-log/releases/tag/v1.0.0) (2023-08-17)
+
+
+### Features
+
+* add goreleaser workflow ([c30d3ac](https://github.com/pixelfactory-go/observability-log/commit/c30d3aceedf8163a11457e5613582b7045cb6398))


### PR DESCRIPTION
Add all missing releases from v1.0.0 through v1.4.1 to the CHANGELOG. Release-please only included v1.4.2 when it regenerated the file, so the complete history has been restored with proper formatting and commit references.

All releases now documented:
- v1.4.2 through v1.4.1 (2026)
- v1.3.2 through v1.3.0 (2024-2026)
- v1.2.0 (2024)
- v1.1.2, v1.1.0 (2023-2024)
- v1.0.1, v1.0.0 (2023)